### PR TITLE
Fix interactive selection syncing

### DIFF
--- a/my_som_dashboard/main.py
+++ b/my_som_dashboard/main.py
@@ -8,7 +8,7 @@ import os
 from bokeh.io import curdoc
 from bokeh.layouts import column, row
 from bokeh.models import CustomJS
-from bokeh.events import ButtonClick
+from bokeh.events import ButtonClick, Tap
 
 from data_loader import load_data, scale_data
 from som_model import train_som, compute_umatrix
@@ -93,7 +93,7 @@ source_hex.selected.js_on_change('indices', CustomJS(args=dict(
     if (inds.length === 0) {
         map_src.selected.indices   = [];
         table_src.selected.indices = [];
-    } else {
+    } else if (inds.length === 1) {
         const idx = inds[0];
         // find all regions with matching BMU coords
         const bx = hex_src.data['bmu_x'][idx];
@@ -110,6 +110,8 @@ source_hex.selected.js_on_change('indices', CustomJS(args=dict(
         // highlight cluster row
         const cl = hex_src.data['hc_cluster'][idx];
         table_src.selected.indices = [cl];
+    } else {
+        return;
     }
     map_src.change.emit();
     table_src.change.emit();
@@ -125,16 +127,53 @@ source_map.selected.js_on_change('indices', CustomJS(args=dict(
     if (inds.length === 0) {
         hex_src.selected.indices   = [];
         table_src.selected.indices = [];
-    } else {
+    } else if (inds.length === 1) {
         const idx = inds[0];
-        // select same unit in hex plot
-        hex_src.selected.indices   = [idx];
-        // highlight cluster row
+        const bx  = map_src.data['bmu_x'][idx];
+        const by  = map_src.data['bmu_y'][idx];
+        const xs  = hex_src.data['bmu_x'];
+        const ys  = hex_src.data['bmu_y'];
+        let hex_i = null;
+        for (let i = 0; i < xs.length; i++) {
+            if (xs[i] === bx && ys[i] === by) { hex_i = i; break; }
+        }
+        hex_src.selected.indices   = hex_i !== null ? [hex_i] : [];
         const cl = map_src.data['hc_cluster'][idx];
         table_src.selected.indices = [cl];
+    } else {
+        return;
     }
     hex_src.change.emit();
     table_src.change.emit();
+"""))
+
+# 6d) Toggle selection on repeated taps
+p_hex.js_on_event(Tap, CustomJS(args=dict(src=source_hex), code="""
+    const inds = src.selected.indices;
+    if (inds.length === 1) {
+        const idx = inds[0];
+        if (src.data._last_sel === idx) {
+            src.selected.indices = [];
+            src.data._last_sel = null;
+        } else {
+            src.data._last_sel = idx;
+        }
+        src.change.emit();
+    }
+"""))
+
+p_map.js_on_event(Tap, CustomJS(args=dict(src=source_map), code="""
+    const inds = src.selected.indices;
+    if (inds.length === 1) {
+        const idx = inds[0];
+        if (src.data._last_sel === idx) {
+            src.selected.indices = [];
+            src.data._last_sel = null;
+        } else {
+            src.data._last_sel = idx;
+        }
+        src.change.emit();
+    }
 """))
 
 # 7) Assemble layout

--- a/my_som_dashboard/plots.py
+++ b/my_som_dashboard/plots.py
@@ -60,7 +60,8 @@ def build_hex_plot(
                 'color':      cluster_palette[int(node_labels[idx])],
                 'alpha':      1.0,
             })
-    node_df     = pd.DataFrame.from_records(records)
+    node_df = pd.DataFrame.from_records(records)
+    node_df["display_color"] = node_df["color"]
     node_source = ColumnDataSource(node_df)
 
     # 3) build the figure
@@ -77,22 +78,22 @@ def build_hex_plot(
     hex_renderer = p_hex.hex_tile(
         q="bmu_x", r="bmu_y", size=1, orientation="flattop",
         source=node_source,
-        fill_color={"field": "color"},
+        fill_color={"field": "display_color"},
         fill_alpha="alpha",
         line_color="#ffffff",
         line_width=0.5,
     )
     hex_renderer.hover_glyph = HexTile(
         q="bmu_x", r="bmu_y", size=1, orientation="flattop",
-        fill_color={"field": "color"}, line_color="#000000"
+        fill_color={"field": "display_color"}, line_color="#000000"
     )
     hex_renderer.selection_glyph = HexTile(
         q="bmu_x", r="bmu_y", size=1, orientation="flattop",
-        fill_color={"field": "color"}, line_color="#000000"
+        fill_color={"field": "display_color"}, line_color="#000000"
     )
     hex_renderer.nonselection_glyph = HexTile(
         q="bmu_x", r="bmu_y", size=1, orientation="flattop",
-        fill_color={"field": "color"}, fill_alpha=0.2, line_color="#ffffff"
+        fill_color={"field": "display_color"}, fill_alpha=0.2, line_color="#ffffff"
     )
 
     # 5) exactly one HoverTool, one tooltip
@@ -123,15 +124,14 @@ def build_hex_plot(
 
     # 7) wire up U-matrix toggle
     toggle.js_on_change('active', CustomJS(
-        args=dict(src=node_source, rend=hex_renderer, bar_c=cb_cl, bar_u=cb_u),
+        args=dict(src=node_source, bar_c=cb_cl, bar_u=cb_u),
         code="""
-            const f = cb_obj.active ? 'u_color' : 'color';
-            rend.glyph.fill_color              = { field: f };
-            rend.hover_glyph.fill_color        = { field: f };
-            rend.selection_glyph.fill_color    = { field: f };
-            rend.nonselection_glyph.fill_color = { field: f };
-            bar_c.visible = !cb_obj.active;
-            bar_u.visible =  cb_obj.active;
+            const showU = cb_obj.active;
+            const colors = showU ? src.data['u_color'] : src.data['color'];
+            // assign a fresh array to ensure change detection
+            src.data['display_color'] = colors.slice();
+            bar_c.visible = !showU;
+            bar_u.visible =  showU;
             src.change.emit();
         """
     ))


### PR DESCRIPTION
## Summary
- synchronize selection between hex plot and map using BMU coordinates
- allow deselecting hexes or regions on repeated taps
- preserve multi-select from cluster buttons
- refresh hex colors immediately when toggling the U-Matrix view

## Testing
- `python -m py_compile my_som_dashboard/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68608a8033108321aece836b228a7182